### PR TITLE
Update to newest rules_go release.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -24,7 +24,7 @@ jobs:
         # allow Bazel to cache intermediate results between the test runs.
         # We’d like to include “rolling” here, but that currently fails due to
         # https://github.com/bazelbuild/bazel/issues/14626.
-        version: [4.2.0, 4.2.1, 4.2.2, 5.0.0, latest]
+        version: [4.2.1, 4.2.2, 5.0.0, latest]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.os}}
     steps:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 
@@ -52,7 +52,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:nogo",
-    version = "1.17.1",
+    version = "1.17.6",
 )
 
 http_archive(


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_go/releases/tag/v0.30.0.