### PR TITLE
Revert "Temporarily exclude latest rolling release from CI"

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -22,9 +22,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        # We’d like to include “rolling” here, but that currently fails due to
-        # https://github.com/bazelbuild/bazel/issues/14626.
-        version: [4.2.1, 4.2.2, 5.0.0, 5.1.0, 5.1.1, 5.2.0, latest]
+        version: [4.2.1, 4.2.2, 5.0.0, 5.1.0, 5.1.1, 5.2.0, latest, rolling]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
This reverts commit 5633441f6a9da1167aa7d3da5462c7cb4ca7a0ac.

This should no longer be needed.