### PR TITLE
Run tests under newly-released Bazel 6.0.0.

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # We don’t use the GitHub matrix support for the Emacs toolchain to
         # allow Bazel to cache intermediate results between the test runs.
-        version: [5.1.0, 5.1.1, 5.2.0, 5.3.0, latest, rolling]
+        version: [5.1.0, 5.1.1, 5.2.0, 5.3.0, 6.0.0, latest, rolling]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/releases/tag/6.0.0.