### PR TITLE
Print arguments passed to “bazel run”

### DIFF
--- a/.github/workflows/bazel-test.yaml
+++ b/.github/workflows/bazel-test.yaml
@@ -45,6 +45,7 @@ jobs:
             build --nostamp
             build --experimental_repository_cache_hardlinks
             test --test_output=errors
+            run --noomit_run_args
           disk-cache: ${{matrix.version}}
           repository-cache: true
       - name: Run Bazel tests

--- a/update-lockfile
+++ b/update-lockfile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024, 2025 Philipp Stephani
+# Copyright 2024-2026 Philipp Stephani
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ gh run download "${id:?}"
 linux=lockfile-Linux-X64/MODULE.bazel.lock
 macos=lockfile-macOS-ARM64/MODULE.bazel.lock
 
-bazel run --lockfile_mode=off -- \
+bazel run --lockfile_mode=off --noomit_run_args -- \
   @phst_merge_bazel_lockfiles//:merge \
   --linux-amd64="${linux:?}" \
   --darwin-arm64="${macos:?}" \


### PR DESCRIPTION
We never pass anything sensitive on the command line, and printing these arguments on the CI logs helps with debugging.